### PR TITLE
Fix typo in contributing.rst

### DIFF
--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -4,18 +4,18 @@
 Contributing
 ************
 
-We welcome contributions -- if you are a localiser then this is your document.
-Please think of this as a living document.  If you are using part of it and
-find that it is out of date then please update it so that others don't have to
-go through your pain.
+We welcome contributions; if you are a localiser then this is your
+document.
+Please think of it as a living document. If you are using any part of it
+and find that it is out of date, then please update it so that others do
+not have to go through your pain.
 
-If you have a new section to contribute or some corrections then please create
-an account and make changes.  If you feel it might be controvercial then please
-email translate-devel@lists.sourceforge.net. If you have some criticism
-we also welcome it but if you accompany it with the changes then you are more
-likely to be listened to (its easy to complain, a little harder to contribute
-meaningfully)
+If you have a new section to contribute or some corrections, please
+create an account and make changes. If you feel it might be
+controversial then please email translate-devel@lists.sourceforge.net. 
+If you have some criticism, we also welcome it, but if you accompany it
+with the changes then you are more likely to be listened to (its easy to
+complain, a little harder to contribute meaningfully).
 
 We :doc:`credit <credits>` those who contribute whole sections and
-significatant update.
-
+significant update.

--- a/docs/guide/copyright.rst
+++ b/docs/guide/copyright.rst
@@ -1,9 +1,6 @@
-
-.. _../pages/guide/copyright#copyright:
-
 Copyright
 *********
 
-The localisation guide is released under the Creative Commons
-`Attribution-ShareAlike <http://creativecommons.org/licenses/by-sa/3.0/>`_
-license.
+The localisation guide is released under the `Creative Commons
+Attribution-ShareAlike <http://creativecommons.org/licenses/by
+-sa/3.0/>`_ license.


### PR DESCRIPTION
A couple edit, since I've found quite some typo in this text, remove double spaces and also improve sentence stresses to help increase readability.

Fix typo in contributing.rst

A couple edit, since I've found quite some typo in this text, remove double spaces and also improve sentence stresses to help increase readability.

Update and rename copyright.rst to copyright.md

Revise copyright link and add image

Update and rename copyright.md to copyright.rst

[x] Return the file type and keep the link correction to pass travis check

Resolve conflict

Fix line wrapping based on @jayvdb's review